### PR TITLE
chore: Enter alpha prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,22 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@plextv/react-lightning-example": "0.4.3",
+    "@plextv/react-native-lightning-example": "0.4.3",
+    "@plextv/react-lightning-storybook": "0.4.3",
+    "@repo/configs": "0.0.3",
+    "@plextv/react-lightning-plugin-css-transform": "0.4.2",
+    "@plextv/react-lightning-plugin-flexbox": "0.4.2",
+    "@plextv/react-lightning-plugin-flexbox-lite": "0.4.2",
+    "@plextv/react-lightning-plugin-reanimated": "0.4.2",
+    "@plextv/react-lightning": "0.4.2",
+    "@plextv/react-lightning-components": "0.4.3",
+    "@plextv/react-native-lightning": "0.4.2",
+    "@plextv/react-native-lightning-components": "0.4.2",
+    "@plextv/vite-plugin-msdf-fontgen": "1.3.7",
+    "@plextv/vite-plugin-react-native-lightning": "0.4.3",
+    "@plextv/vite-plugin-react-reanimated-lightning": "0.4.3"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
## What

Re-enters changesets pre mode with tag `alpha` by re-adding `.changeset/pre.json`. This was previously removed in `12e105e` ("Remove prerelease") when the repo exited prerelease.

## Why

We want to start shipping alpha versions again. Pre mode's presence is driven entirely by `pre.json` — while it exists on `main`, `changeset version`/`publish` (via the release workflow) produce `-alpha.N` versions on the npm `alpha` dist-tag instead of stable bumps on `latest`.

## After merge

- The release workflow's "Version Packages" PR will target alpha versions.
- Continue adding changesets per change as usual; they're consumed as alpha bumps while pre mode is active.
- To go stable again, run `changeset pre exit` and remove `pre.json`.