### PR TITLE
chore: keep alpha releases on 0.x (downgrade minor changesets to patch)

### DIFF
--- a/.changeset/flatten-layout-views.md
+++ b/.changeset/flatten-layout-views.md
@@ -1,5 +1,5 @@
 ---
-'@plextv/react-lightning': minor
+'@plextv/react-lightning': patch
 ---
 
 Add a `flattenLayoutViews` render option: layout-only Views (no background, border, clip, non-neutral alpha/transform, or transition) skip renderer node creation entirely. The element keeps a lightweight placeholder, descendants attach to the nearest materialized ancestor, and layout positions accumulate across the flattened chain (folded at the layout write funnels, unwound in `getRelativePosition`/`onLayout`). A flattened element materializes a real node on the first prop that needs one (sticky, so per-focus style toggles don't churn nodes). Inert RN-layer props (handlers, testID) don't prevent flattening; visual props at neutral values (color 0, alpha 1, scale 1) don't either. Off by default.

--- a/.changeset/flexbox-sync-flush-settled.md
+++ b/.changeset/flexbox-sync-flush-settled.md
@@ -1,5 +1,5 @@
 ---
-'@plextv/react-lightning-plugin-flexbox': minor
+'@plextv/react-lightning-plugin-flexbox': patch
 ---
 
 Add a synchronous flushLayout() that lays out to a fixpoint, and a settled event that fires once layout converges. Deterministic replacement for the timer-based "has it settled yet" guesses in VirtualList.

--- a/.changeset/lightning-flex-nonzero-sizing.md
+++ b/.changeset/lightning-flex-nonzero-sizing.md
@@ -1,5 +1,5 @@
 ---
-"@plextv/react-lightning": minor
+"@plextv/react-lightning": patch
 "@plextv/react-lightning-plugin-flexbox": patch
 ---
 

--- a/.changeset/lightning-focus-engine.md
+++ b/.changeset/lightning-focus-engine.md
@@ -1,5 +1,5 @@
 ---
-"@plextv/react-lightning": minor
+"@plextv/react-lightning": patch
 ---
 
 feat(focus): focus-when-ready, arrival-not-mount autoFocus, and destinations-on-arrival

--- a/.changeset/lightning-image-border-paint.md
+++ b/.changeset/lightning-image-border-paint.md
@@ -1,5 +1,5 @@
 ---
-"@plextv/react-lightning": minor
+"@plextv/react-lightning": patch
 "@plextv/react-native-lightning": patch
 ---
 

--- a/.changeset/lightning-input-events.md
+++ b/.changeset/lightning-input-events.md
@@ -1,5 +1,5 @@
 ---
-"@plextv/react-lightning": minor
+"@plextv/react-lightning": patch
 ---
 
 fix(input): normalize key events and stop swallowing held-key auto-repeat

--- a/.changeset/lightning-text-intrinsic-sizing.md
+++ b/.changeset/lightning-text-intrinsic-sizing.md
@@ -1,5 +1,5 @@
 ---
-"@plextv/react-lightning-plugin-flexbox": minor
+"@plextv/react-lightning-plugin-flexbox": patch
 "@plextv/react-lightning": patch
 ---
 

--- a/.changeset/lightning-virtuallist-parity.md
+++ b/.changeset/lightning-virtuallist-parity.md
@@ -1,5 +1,5 @@
 ---
-"@plextv/react-lightning-components": minor
+"@plextv/react-lightning-components": patch
 ---
 
 feat(virtuallist): getLayout ref API and skipChildFocusScroll opt-out for FlashList parity

--- a/.changeset/reanimated-dep-inference.md
+++ b/.changeset/reanimated-dep-inference.md
@@ -1,5 +1,5 @@
 ---
-'@plextv/react-lightning-plugin-reanimated': minor
+'@plextv/react-lightning-plugin-reanimated': patch
 ---
 
 Infer reanimated hook dependencies at runtime by tracking shared-value reads. No babel plugin runs on Lightning, so `useAnimatedStyle` / `useDerivedValue` / `useAnimatedReaction` without an explicit dependency array never subscribed to their shared values and only updated on re-renders. Shared values from `useSharedValue` / `makeMutable` now report reads to the active hook, which subscribes to exactly what its updater read (re-collected on every run, so branches are handled). Explicit dependency arrays keep their old behavior.


### PR DESCRIPTION
The alpha release PR (#111) bumped most packages to `1.0.0-alpha.0`. That's not a real major: `@plextv/react-lightning` (and `plugin-flexbox`) have `minor` changesets, so they'd go `0.4.2 → 0.5.0`, which falls outside the `^0.4.2` peer range every plugin/dependent declares. changesets treats an out-of-range peer bump as breaking for consumers and cascades a **major** onto all of them → `1.0.0`.

To stay on `0.x`, this downgrades the 9 `minor` changesets to `patch`. Everything then bumps within `^0.4.x` (no out-of-range peer change, no major cascade). Verified locally with `changeset version` in pre mode:

- before: `react-lightning 0.5.0-alpha.0`, everything else `1.0.0-alpha.0`
- after: all packages `0.4.3/0.4.4-alpha.0`

Trade-off: a few genuinely feature-level changes now land as `patch` in the changelogs. For a pre-1.0 framework in active alpha churn that's fine, and it keeps `1.0.0` unspent until we actually mean it. Once this merges, the changesets action will regenerate #111 with the `0.4.x` versions.
