### PR TITLE
fix: don't assume react-native ViewProps declares onFocusCapture, gate check:types in CI

### DIFF
--- a/.changeset/view-focus-capture-optional-rn-prop.md
+++ b/.changeset/view-focus-capture-optional-rn-prop.md
@@ -1,0 +1,5 @@
+---
+'@plextv/react-native-lightning': patch
+---
+
+`View`'s `onFocusCapture` type no longer assumes `react-native`'s `ViewProps` declares the prop. react-native-tvos has it, plain react-native doesn't, so the indexed access was a hard `check:types` error for anyone on upstream react-native. Reads the prop only when it's actually present, so both forks typecheck.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Check types
+        run: pnpm run check:types
+
       - name: Run unit tests
         run: pnpm run test

--- a/packages/react-native-lightning/src/exports/View.tsx
+++ b/packages/react-native-lightning/src/exports/View.tsx
@@ -16,6 +16,12 @@ import { useLayoutHandler } from '../hooks/useLayoutHandler';
 import type { NativeLightningViewElement } from '../types/NativeLightningViewElement';
 import { isFocusActive, shouldRegisterFocus } from './focusableView';
 
+// react-native-tvos declares onFocusCapture on ViewProps, plain react-native
+// doesn't. Generic so the indexed access stays deferred and compiles on both.
+type FocusCaptureOf<P> = 'onFocusCapture' extends keyof P
+  ? P['onFocusCapture']
+  : never;
+
 type CombinedProps = Omit<
   RNViewProps &
     LightningViewElementProps &
@@ -28,7 +34,7 @@ type CombinedProps = Omit<
   // intersecting them yields a signature no handler can satisfy. Accept either.
   onFocusCapture?:
     | FocusableProps['onFocusCapture']
-    | RNViewProps['onFocusCapture'];
+    | FocusCaptureOf<RNViewProps>;
   // Directional-only focus catcher: reachable by a deliberate move but never
   // by restoration or the mount-time default (drawer edge guard).
   focusRestorationExcluded?: boolean;


### PR DESCRIPTION
Merging #117 left `main` failing `check:types`, which blocks the release job: the changesets action can't push `changeset-release/main` because the husky pre-push hook runs `check:types` and it exits 2. No version PR got created and nothing published.

```
../react-native-lightning/src/exports/View.tsx(31,19): error TS2339:
  Property 'onFocusCapture' does not exist on type 'ViewProps'
Failed: @plextv/react-native-lightning-components#check:types
husky - pre-push script failed (code 2)
```

The cause: `View`'s `CombinedProps` reads `RNViewProps['onFocusCapture']`. react-native-tvos declares that prop on `ViewProps` (`Libraries/Types/CoreEventTypes.d.ts`), plain react-native doesn't. The change was written and typechecked against the Plex client, which aliases `react-native` to `react-native-tvos`, so it compiled there and not here.

Reads the prop only when it's present. Generic, so the indexed access stays deferred (a non-generic conditional doesn't narrow it and fails with `TS2538` instead):

```ts
type FocusCaptureOf<P> = 'onFocusCapture' extends keyof P
  ? P['onFocusCapture']
  : never;
```

Both forks typecheck, and consumers on tvos keep the handler type they had.

Second commit closes the hole that let this through: PR CI ran `lint` + `test` but not `check:types`, so a type error couldn't fail a PR — it only surfaced later as a failed push inside the release job, reading as a git error rather than a type error. `check:types` now runs on pull requests, and this PR is the first run to exercise it (13/13 packages, ~23s).

Verified against a real install of this repo, not just in the abstract: `check:types` 13/13, `lint` 0 errors, `test` 728 passing across 62 files.
